### PR TITLE
Use clientOwner to generate OOP object IDs

### DIFF
--- a/Project_0.Altis/Misc/fn_boundingBoxReal.sqf
+++ b/Project_0.Altis/Misc/fn_boundingBoxReal.sqf
@@ -9,9 +9,18 @@ _vehType - String, class name of the vehicle
 Author: Sparker 29.07.2018
 */
 
-params ["_vehType"];
+params [["_vehType", "", [""]]];
 
-private _veh = _vehType createVehicleLocal [0, 0, 666]; //createSimpleObject [_vehType, [0, 0, 666]];
-private _bb = boundingBoxReal _veh;
-deleteVehicle _veh;
+// Check if we have it in cache. CreateVehicleLocal takes 5.6 ms
+private _cacheEntry = "bbcache_"+_vehType;
+
+private _bb = missionNamespace getVariable _cacheEntry;
+
+if (isNil "_bb") then {
+	private _veh = _vehType createVehicleLocal [0, 0, 666]; //createSimpleObject [_vehType, [0, 0, 666]];
+	_bb = boundingBoxReal _veh;
+	deleteVehicle _veh;
+	missionNamespace setVariable [_cacheEntry, _bb];
+};
+
 _bb

--- a/Project_0.Altis/OOP_Light/OOP_Light.h
+++ b/Project_0.Altis/OOP_Light/OOP_Light.h
@@ -169,7 +169,7 @@
 // ----------------------------------------------------------------------
 
 //Name of a specific instance of object
-#define OBJECT_NAME_STR(classNameStr, objIDInt) (OOP_PREFIX + (classNameStr) + OBJECT_SEPARATOR + (format ["%1", objIDInt]))
+#define OBJECT_NAME_STR(classNameStr, objIDInt)  (format ["%1%2%3%4_%5", OOP_PREFIX, classNameStr, OBJECT_SEPARATOR, clientOwner, objIDInt])
 
 //String name of a static member
 #define CLASS_STATIC_MEM_NAME_STR(classNameStr, memNameStr) ((OOP_PREFIX) + (classNameStr) + STATIC_SEPARATOR + (memNameStr))

--- a/Project_0.Altis/OOP_Light/OOP_Light.h
+++ b/Project_0.Altis/OOP_Light/OOP_Light.h
@@ -72,7 +72,7 @@
 
 #define TIME_NOW 0
 #define DATE_NOW [0,0,0,0,0]
-#define CLIENT_OWNER objNull
+#define CLIENT_OWNER 0
 #define IS_SERVER true
 #define HAS_INTERFACE true
 #define IS_HEADLESSCLIENT false
@@ -169,7 +169,7 @@
 // ----------------------------------------------------------------------
 
 //Name of a specific instance of object
-#define OBJECT_NAME_STR(classNameStr, objIDInt)  (format ["%1%2%3%4_%5", OOP_PREFIX, classNameStr, OBJECT_SEPARATOR, clientOwner, objIDInt])
+#define OBJECT_NAME_STR(classNameStr, objIDInt)  (format ["%1%2%3%4_%5", OOP_PREFIX, classNameStr, OBJECT_SEPARATOR, CLIENT_OWNER, objIDInt])
 
 //String name of a static member
 #define CLASS_STATIC_MEM_NAME_STR(classNameStr, memNameStr) ((OOP_PREFIX) + (classNameStr) + STATIC_SEPARATOR + (memNameStr))

--- a/Project_0.Altis/Unit/Unit.sqf
+++ b/Project_0.Altis/Unit/Unit.sqf
@@ -248,7 +248,7 @@ CLASS(UNIT_CLASS_NAME, "");
 					private _subcatID = _data select UNIT_DATA_ID_SUBCAT;
 					
 					// Check if it's a static vehicle. If it is, we can create it wherever we want without engine-provided collision check
-					pr _special = "NONE";
+					pr _special = "CAN_COLLIDE";
 					/*
 					if ([_catID, _subcatID] in T_static) then {
 						_special = "CAN_COLLIDE";


### PR DESCRIPTION
Now when a new object is created, it gets a clientOwner ID in its name, which is unique in MP environment for every client. This helps avoid collisions when we are transferring data of different objects across network.