### PR TITLE
Prevent soldiers in vehicles from harassing people

### DIFF
--- a/Project_0.Altis/AI/Garrison/ActionGarrisonMoveMounted.sqf
+++ b/Project_0.Altis/AI/Garrison/ActionGarrisonMoveMounted.sqf
@@ -118,6 +118,17 @@ CLASS(THIS_ACTION_NAME, "ActionGarrison")
 			pr _pos = CALLM0(_gar, "getPos");
 			[_ws, WSP_GAR_POSITION, _pos] call ws_setPropertyValue;
 			
+			// Give goals to infantry groups
+			pr _groupTypes = [GROUP_TYPE_IDLE, GROUP_TYPE_BUILDING_SENTRY, GROUP_TYPE_PATROL];
+			pr _infGroups = CALLM1(_gar, "findGroupsByType", _groupTypes);
+			{
+				pr _group = _x;
+				pr _groupAI = CALLM0(_x, "getAI");
+				// Add new goal to stay in vehicles
+				pr _args = ["GoalGroupStayInVehicles", 0, [], _AI];
+				CALLM2(_groupAI, "postMethodAsync", "addExternalGoal", _args);		
+			} forEach _infGroups;
+
 			// Set state
 			SETV(_thisObject, "state", ACTION_STATE_ACTIVE);
 			
@@ -263,6 +274,17 @@ CLASS(THIS_ACTION_NAME, "ActionGarrison")
 			pr _args = ["GoalGroupMoveGroundVehicles", ""];
 			CALLM2(_groupAI, "postMethodAsync", "deleteExternalGoal", _args);			
 		} forEach _vehGroups;
+
+		// Terminate infantry group goals
+		pr _groupTypes = [GROUP_TYPE_IDLE, GROUP_TYPE_BUILDING_SENTRY, GROUP_TYPE_PATROL];
+		pr _infGroups = CALLM1(_gar, "findGroupsByType", _groupTypes);
+		{
+			pr _group = _x;
+			pr _groupAI = CALLM0(_x, "getAI");
+			// Add new goal to stay in vehicles
+			pr _args = ["GoalGroupStayInVehicles", ""];
+			CALLM2(_groupAI, "postMethodAsync", "deleteExternalGoal", _args);		
+		} forEach _infGroups;
 		
 	} ENDMETHOD;
 

--- a/Project_0.Altis/AI/Group/ActionGroupStayInVehicles.sqf
+++ b/Project_0.Altis/AI/Group/ActionGroupStayInVehicles.sqf
@@ -1,0 +1,39 @@
+#include "common.hpp"
+
+/*
+Class: ActionGroup.ActionGroupStayInVehicles
+Group members will remain inside their current vehicles.
+Currently it does nothing, but it could potentially perform monitoring of units to stay inside vehicles.
+*/
+
+#define pr private
+
+CLASS("ActionGroupStayInVehicles", "ActionGroup")
+	
+	// ------------ N E W ------------
+
+	// logic to run when the goal is activated
+	METHOD("activate") {
+		params [["_thisObject", "", [""]]];		
+		
+		// Return ACTIVE state
+		T_SETV("state", ACTION_STATE_ACTIVE);
+		ACTION_STATE_ACTIVE
+	} ENDMETHOD;
+	
+	// logic to run each update-step
+	METHOD("process") {
+		params [["_thisObject", "", [""]]];
+		
+		pr _state = CALLM0(_thisObject, "activateIfInactive");
+
+		_state
+	} ENDMETHOD;
+	
+	// logic to run when the action is satisfied
+	METHOD("terminate") {
+		params [["_thisObject", "", [""]]];
+		
+	} ENDMETHOD;
+
+ENDCLASS;

--- a/Project_0.Altis/AI/Group/GoalGroupArrest.sqf
+++ b/Project_0.Altis/AI/Group/GoalGroupArrest.sqf
@@ -25,7 +25,7 @@ CLASS("GoalGroupArrest", "Goal")
 		if !(isNil "_suspTarget") then { 
 			if (behaviour leader _hG == "COMBAT") then { _relevance = 0; } 
 			else {
-				_relevance = 120;
+				_relevance = GETSV("GoalGroupArrest", "relevance");
 			};
 		} else {
 			OOP_INFO_0("GoalGroupArrest: Evaluating relevance.");

--- a/Project_0.Altis/AI/Group/GoalGroupRelax.sqf
+++ b/Project_0.Altis/AI/Group/GoalGroupRelax.sqf
@@ -1,7 +1,7 @@
 #include "common.hpp"
 
 /*
-Goal for a group to perform patrol.
+Goal for a group to relax.
 */
 
 #define pr private

--- a/Project_0.Altis/AI/Group/GoalGroupStayInVehicles.sqf
+++ b/Project_0.Altis/AI/Group/GoalGroupStayInVehicles.sqf
@@ -1,0 +1,11 @@
+#include "common.hpp"
+
+/*
+Goal for a group to stay inside their vehicles.
+*/
+
+#define pr private
+
+CLASS("GoalGroupStayInVehicles", "Goal")
+
+ENDCLASS;

--- a/Project_0.Altis/AI/Group/initClasses.sqf
+++ b/Project_0.Altis/AI/Group/initClasses.sqf
@@ -14,6 +14,7 @@ call compile preprocessFileLineNumbers "AI\Group\ActionGroupOccupySentryPosition
 call compile preprocessFileLineNumbers "AI\Group\ActionGroupPatrol.sqf";
 call compile preprocessFileLineNumbers "AI\Group\ActionGroupRegroup.sqf";
 call compile preprocessFileLineNumbers "AI\Group\ActionGroupRelax.sqf";
+call compile preprocessFileLineNumbers "AI\Group\ActionGroupStayInVehicles.sqf";
 call compile preprocessFileLineNumbers "AI\Group\ActionGroupSurrender.sqf";
 call compile preprocessFileLineNumbers "AI\Group\ActionGroupUnflipVehicles.sqf";
 call compile preprocessFileLineNumbers "AI\Group\ActionGroupVehicleClearArea.sqf";
@@ -30,6 +31,7 @@ call compile preprocessFileLineNumbers "AI\Group\GoalGroupOccupySentryPositions.
 call compile preprocessFileLineNumbers "AI\Group\GoalGroupPatrol.sqf";
 call compile preprocessFileLineNumbers "AI\Group\GoalGroupRegroup.sqf";
 call compile preprocessFileLineNumbers "AI\Group\GoalGroupRelax.sqf";
+call compile preprocessFileLineNumbers "AI\Group\GoalGroupStayInVehicles.sqf";
 call compile preprocessFileLineNumbers "AI\Group\GoalGroupSurrender.sqf";
 call compile preprocessFileLineNumbers "AI\Group\GoalGroupUnflipVehicles.sqf";
 call compile preprocessFileLineNumbers "AI\Group\_SensorGroup.sqf";

--- a/Project_0.Altis/AI/Group/initDatabase.sqf
+++ b/Project_0.Altis/AI/Group/initDatabase.sqf
@@ -14,10 +14,11 @@ Initializes costs, effects and preconditions of actions, relevance values of goa
 ["GoalGroupRelax",								1] call AI_misc_fnc_setGoalIntrinsicRelevance;
 ["GoalGroupNothing",							2] call AI_misc_fnc_setGoalIntrinsicRelevance;
 ["GoalGroupPatrol",								30] call AI_misc_fnc_setGoalIntrinsicRelevance;
-["GoalGroupArrest",								72] call AI_misc_fnc_setGoalIntrinsicRelevance;
+["GoalGroupArrest",								32] call AI_misc_fnc_setGoalIntrinsicRelevance;
 ["GoalGroupRegroup",							35] call AI_misc_fnc_setGoalIntrinsicRelevance;
 ["GoalGroupGetInVehiclesAsCrew",				40] call AI_misc_fnc_setGoalIntrinsicRelevance;
 ["GoalGroupGetInGarrisonVehiclesAsCargo",		40] call AI_misc_fnc_setGoalIntrinsicRelevance;
+["GoalGroupStayInVehicles",						40] call AI_misc_fnc_setGoalIntrinsicRelevance;
 ["GoalGroupOccupySentryPositions",				50] call AI_misc_fnc_setGoalIntrinsicRelevance;
 ["GoalGroupMoveGroundVehicles",					60] call AI_misc_fnc_setGoalIntrinsicRelevance;
 ["GoalGroupInfantryMove",						61] call AI_misc_fnc_setGoalIntrinsicRelevance;
@@ -40,6 +41,7 @@ Initializes costs, effects and preconditions of actions, relevance values of goa
 ["GoalGroupPatrol", "ActionGroupPatrol"] call AI_misc_fnc_setGoalPredefinedAction;
 ["GoalGroupArrest", "ActionGroupArrest"] call AI_misc_fnc_setGoalPredefinedAction;
 ["GoalGroupRegroup", "ActionGroupRegroup"] call AI_misc_fnc_setGoalPredefinedAction;
+["GoalGroupStayInVehicles", "ActioNGroupStayInVehicles"] call AI_misc_fnc_setGoalPredefinedAction;
 ["GoalGroupGetInVehiclesAsCrew", "ActionGroupGetInVehiclesAsCrew"] call AI_misc_fnc_setGoalPredefinedAction;
 ["GoalGroupGetInGarrisonVehiclesAsCargo", "ActionGroupGetInGarrisonVehiclesAsCargo"] call AI_misc_fnc_setGoalPredefinedAction;
 ["GoalGroupOccupySentryPositions", "ActionGroupOccupySentryPositions"] call AI_misc_fnc_setGoalPredefinedAction;


### PR DESCRIPTION
Previously soldiers would dismount vehicles and start harassing civilians at all costs even if they were travelling in a vehicle, which was causing problems for convoys. Now it is fixed.